### PR TITLE
Fix issue with Cluster.adapt() returning a non-picklable

### DIFF
--- a/dask_remote/runner/api.py
+++ b/dask_remote/runner/api.py
@@ -44,16 +44,16 @@ def cluster_api(cluster_proxy: ClusterProcessProxy, fastapi_kwargs: dict) -> Fas
         if n < 0:
             n = 0
         app.cluster._adaptive_stop()
-        app.cluster.scale(n)
-        return MessageResponse(message=f"Scaling to {n} workers")
+        response = app.cluster.scale(n)
+        return MessageResponse(message=str(response))
 
     @app.post("/adapt", response_model=MessageResponse)
     async def adapt(minimum: int = 0, maximum: Optional[int] = None):
         """Set cluster to adaptive scaling mode."""
         if maximum is None:
             maximum = math.inf
-        app.cluster.adapt(minimum=minimum, maximum=maximum)
-        return MessageResponse(message=f"Adapting between {minimum} and {maximum}")
+        response = app.cluster.adapt(minimum=minimum, maximum=maximum)
+        return MessageResponse(message=str(response))
 
     return app
 

--- a/dask_remote/runner/cluster_process.py
+++ b/dask_remote/runner/cluster_process.py
@@ -124,7 +124,10 @@ class ClusterProcess(Process):
             result = self._call_cmd(cmd, cluster)
         except Exception as e:
             result = e
-        self.result_conn.send(result)
+        try:
+            self.result_conn.send(result)
+        except Exception as e:
+            self.result_conn.send(e)
 
     @staticmethod
     def _call_cmd(cmd, obj):

--- a/tests/test_unit/test_runner/conftest.py
+++ b/tests/test_unit/test_runner/conftest.py
@@ -11,10 +11,6 @@ class PingCluster:
         self.n = n
 
     @property
-    def scheduler_info(self):
-        return dict(workers=list(range(self.n)))
-
-    @property
     def workers(self):
         return list(range(self.n))
 
@@ -30,12 +26,9 @@ class PingCluster:
         self.n = n
         return f"scale({n})"
 
-    @property
-    def attribute(self):
-        return "attribute"
-
-    def method(self, n):
-        return f"method({n})"
+    def adapt(self, **kwargs):
+        """Not picklable"""
+        return lambda: None
 
 
 @pytest.fixture

--- a/tests/test_unit/test_runner/test_api.py
+++ b/tests/test_unit/test_runner/test_api.py
@@ -18,7 +18,7 @@ def test_status(client):
 def test_scale(client):
     response = client.post("/scale/42")
     assert response.status_code == 200
-    assert response.json() == {"message": "Scaling to 42 workers"}
+    assert response.json() == {"message": "scale(42)"}
 
     response = client.get("/scale")
     assert response.json() == {"message": "42"}


### PR DESCRIPTION
Before this change, the process would error when the return result from a method or attribute was not picklable, and could therefore not be returned to the Proxy through the results pipe.

After this change, error handling is added for `Connection.send` itself, return pickling error if needed.