### PR TITLE
Handle non-picklable return values using a custom Exception

### DIFF
--- a/dask_remote/runner/cluster_process.py
+++ b/dask_remote/runner/cluster_process.py
@@ -1,15 +1,5 @@
 """
 Run Cluster in a separata process, and expose its scaling commands through a "proxy".
-
->>> from multiprocessing import Pipe
->>> from dask.distributed import LocalCluster
->>> from dask_remote import ClusterProcess, ClusterProcessProxy
->>> cmd_conn, result_conn = Pipe()
->>> cluster_proc = ClusterProcess(cmd_conn, result_conn, LocalCluster, dict(n_workers=0))
->>> cluster_proc.start()  # uses the multiprocessing.Process API
->>> cluster_proxy = ClusterProcessProxy(cmd_conn, result_conn)
->>> cluster_proxy.scale(4)  # command is proxied to the cluster object in the child process
->>> cluster_prox.join()  # cluster remains alive until terminated
 """
 from multiprocessing import Process
 from multiprocessing.connection import Connection, Pipe

--- a/tests/test_unit/test_runner/test_api.py
+++ b/tests/test_unit/test_runner/test_api.py
@@ -22,3 +22,9 @@ def test_scale(client):
 
     response = client.get("/scale")
     assert response.json() == {"message": "42"}
+
+
+def test_adapt(client):
+    response = client.post("/adapt?minimum=0&maximum=42")
+    assert response.status_code == 200
+    assert response.json() == {"message": "None"}

--- a/tests/test_unit/test_runner/test_cluster_process.py
+++ b/tests/test_unit/test_runner/test_cluster_process.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dask_remote.runner.cluster_process import ClusterProcess
+from dask_remote.runner.cluster_process import ClusterProcess, ResultPicklingError
 
 from .conftest import PingCluster
 
@@ -71,7 +71,7 @@ class TestClusterProcess:
         cluster_process._cmd_pipe[0].send(cmd)
         result = cluster_process._result_pipe[1].recv()
 
-        assert isinstance(result, AttributeError)
+        assert isinstance(result, ResultPicklingError)
 
     def test_returns_error(self, cluster_process):
         cmd = {"attribute": "not_an_attribute"}


### PR DESCRIPTION
Before this change, the pickling exception (`AttriobuteError`) in `send` was returned to the Proxy, but could not be distinguished from other error types. With a custom exception type, we can handle the case separately. The error now gets logged in the Proxy (parent) process, and `None` is returned - e.g. to the API.