### PR TITLE
Disable CircleCI git caching at checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,19 +21,6 @@ executors:
 
 commands:
 
-  checkout_source:
-    steps:
-      - restore_cache:
-          keys:
-            - source-{{ .Branch }}-{{ .Revision }}
-            - source-{{ .Branch }}-
-            - source-
-      - checkout
-      - save_cache:
-          key: source-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - "./.git"
-
   update_virtualenv:
     steps:
       - restore_cache:
@@ -59,7 +46,7 @@ jobs:
   lint:
     executor: standard
     steps:
-      - checkout_source
+      - checkout
       - update_virtualenv
       - run:
           name: Run Python linter
@@ -70,7 +57,7 @@ jobs:
     environment:
       TEST_GROUP: "unit"
     steps:
-      - checkout_source
+      - checkout
       - update_virtualenv
       - run:
           name: Run Python tests
@@ -81,7 +68,7 @@ jobs:
   build:
     executor: standard
     steps:
-      - checkout_source
+      - checkout
       - update_virtualenv
       - run:
           name: Build wheel
@@ -93,7 +80,7 @@ jobs:
   publish:
     executor: standard
     steps:
-      - checkout_source
+      - checkout
       - update_virtualenv
       - run:
           name: Publish wheel


### PR DESCRIPTION
CircleCI git checkout doesn’t pull new tags once git repo is cached
https://discuss.circleci.com/t/builds-using-git-tags-failing/14904